### PR TITLE
fix: 防止首頁輪播左右邊界破圖

### DIFF
--- a/src/swiper.js
+++ b/src/swiper.js
@@ -4,6 +4,7 @@ import { Navigation, Pagination } from 'swiper/modules';
 const swiper = new Swiper('.bgSwiper', {
   modules: [Navigation, Pagination],
   grabCursor: true,
+  resistanceRatio: 0,
   navigation: {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev'


### PR DESCRIPTION
修正首頁 swiper 左右邊界圖片用手指滑動時破圖